### PR TITLE
PayEx → Swedbank Pay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# payex.github.io
+# swedbankpay.github.io
 
-This is the repository for [PayEx on GitHub][1]. It is run as a [Jekyll][2]
+This is the repository for [Swedbank Pay on GitHub][1]. It is run as a [Jekyll][2]
 website on [GitHub Pages][3].
 
 ## Usage
 
-To view this website, browse to [payex.github.io][1]. If you'd like to host it
+To view this website, browse to [swedbankpay.github.io][1]. If you'd like to host it
 locally on your computer, you need to do the following:
 
 1. [Clone this repository][4].
@@ -29,14 +29,14 @@ well as [PayEx Open Source Development Guidelines][10].
 This website is available as open source under the terms of the
 [MIT License][11].
 
-[1]: https://payex.github.io
+[1]: https://swedbankpay.github.io
 [2]: https://jekyllrb.com/
 [3]: https://pages.github.com/
 [4]: https://help.github.com/articles/cloning-a-repository/
 [5]: https://www.ruby-lang.org/en/
 [6]: https://rubygems.org/
 [7]: https://bundler.io/
-[8]: https://github.com/PayEx/payex.github.io/
+[8]: https://github.com/SwedbankPay/swedbankpay.github.io/
 [9]: http://contributor-covenant.org
 [10]: https://developer.payex.com/xwiki/wiki/developer/view/Main/guidelines/open-source-development-guidelines/
 [11]: https://opensource.org/licenses/MIT

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
-repository: PayEx/payex.github.io
-remote_theme: PayEx/payex-design-guide-jekyll-theme
+repository: SwedbankPay/swedbankpay.github.io
+remote_theme: SwedbankPay/swedbank-pay-design-guide-jekyll-theme
 exclude: ["Gemfile*", "Rakefile"]
 plugins:
   - "jekyll-github-metadata"

--- a/index.md
+++ b/index.md
@@ -1,20 +1,8 @@
 ---
-title: PayEx Open Source Repositories
-active_modules:
-- payex-woocommerce-checkout
-- payex-woocommerce-payments
-- payex-magento2-checkout
-legacy:
-- PayEx.Magento
-- PayEx.Magento2
-- PayEx.EPi.Commerce.Payment
-- PayEx.WooCommerce
-- PayEx.PrestaShop
-- PayEx.OpenCart2
-- django-payex
-- pypayex
+title: Swedbank Pay Open Source Repositories
 libraries:
-- payex-sdk-php
+- swedbank-pay-sdk-android
+- swedbank-pay-sdk-ios
 ---
 
 {% comment %}
@@ -22,58 +10,31 @@ TODO: Figure how to retrieve repository.topics for all repositories and use it t
 {% endcomment %}
 
 {% assign active_repositories = site.github.public_repositories | where: 'archived', false %}
-{% assign archived_repositories = site.github.public_repositories | where: 'archived', true %}
-{% assign excluded = page.legacy | concat: page.libraries | concat: page.active_modules %}
+{% assign excluded = page.libraries %}
 
-Here you will find PayEx' open source repositories. They should all be written according to
-[PayEx Open Source Development Guidelines][1].
-
-## Modules
-
-Actively maintained modules, plugins and extensions for web shop platforms such as WooCommerce and Magento.
-
-{% for repository in active_repositories %}
-  {% if page.active_modules contains repository.name %}
-  * [{{ repository.name }}]({{ repository.html_url }}): {{ repository.description }}
-  {% endif %}
-{% endfor %}
+Here you will find Swedbank Pay's open source repositories. They should all be
+written according to [PayEx Open Source Development Guidelines][1].
 
 ## Libraries and SDKs
 
-Actively maintained libraries and SDKs for PayEx' API platform.
+Actively maintained libraries and SDKs for Swedbank Pay' API platform.
 
 {% for repository in active_repositories %}
   {% if page.libraries contains repository.name %}
-  * [{{ repository.name }}]({{ repository.html_url }}): {{ repository.description }}
+  * [{{repository.description}}]({{ repository.html_url }})
   {% endif %}
 {% endfor %}
 
-## Other 
+## Other
 
-Other open source repositories hosted by PayEx, such as the PayEx Design Guide, etc.
+Other open source repositories hosted by Swedbank Pay, such as the Swedbank Pay
+Design Guide, etc.
 
 {% for repository in active_repositories %}
   {% unless excluded contains repository.name %}
-  * [{{ repository.name }}]({{ repository.html_url }}): {{ repository.description }}
+  * [{{ repository.description }}]({{ repository.html_url }})
   {% endunless %}
 {% endfor %}
 
-## Legacy
-
-These legacy modules, libraries and SDKs integrate against PayEx' old SOAP-based eCommerce-platform commonly referred to as "POPS".
-
-{% for repository in active_repositories %}
-  {% if page.legacy contains repository.name %}
-  * [{{ repository.name }}]({{ repository.html_url }}): {{ repository.description }}
-  {% endif %}
-{% endfor %}
-
-## Archive
-
-These repostories are archived and no longer maintained by PayEx.
-
-{% for repository in archived_repositories %}
-  * [{{ repository.name }}]({{ repository.html_url }}): {{ repository.description }}
-{% endfor %}
 
 [1]: https://developer.payex.com/xwiki/wiki/developer/view/Main/guidelines/open-source-development-guidelines/


### PR DESCRIPTION
- Replace occurrences of `PayEx` with `Swedbank Pay`
- Change from PayEx Design Guide to Swedbank Pay Design Guide